### PR TITLE
feat(docusaurus): website tweaks

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -110,13 +110,12 @@ const config = {
                 docId: 'developer/README',
                 label: 'Developer Manual',
               },
+              {
+                type: 'doc',
+                docId: 'whitepapers/README',
+                label: 'Whitepapers',
+              },
             ],
-          },
-          {
-            type: 'doc',
-            docId: 'whitepapers/README',
-            label: 'Whitepapers',
-            position: 'right',
           },
         ],
       },

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -11,6 +11,7 @@ import React from 'react';
 import Modal from 'react-overlays/Modal';
 import {Transition} from 'react-transition-group';
 import clsx from 'clsx';
+import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import {useColorMode} from '@docusaurus/theme-common';
@@ -260,6 +261,16 @@ const Fade = ({children, ...props}) => (
   </Transition>
 );
 
+const LayoutWrapper = props => (
+  <>
+    <Layout {...props} />
+    <Head titleTemplate="%s">
+      {props.title && <title>{props.title}</title>}
+      {props.title && <meta property="og:title" content={props.title} />}
+    </Head>
+  </>
+);
+
 export default function Home() {
   const context = useDocusaurusContext();
   const {siteConfig = {}} = context;
@@ -275,7 +286,7 @@ export default function Home() {
   );
 
   return (
-    <Layout title="Home" description={siteConfig.tagline}>
+    <LayoutWrapper title="Terragraph" description={siteConfig.tagline}>
       <header className={clsx('hero', styles.heroBanner)}>
         <div className={styles.heroVideo}>
           <video
@@ -436,6 +447,6 @@ export default function Home() {
         aria-label="Partner details">
         {partnerModalData && <PartnerModal {...partnerModalData} />}
       </Modal>
-    </Layout>
+    </LayoutWrapper>
   );
 }


### PR DESCRIPTION
Signed-off-by: Jeffrey Han <39203126+elludraon@users.noreply.github.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

Some minor Docusaurus website tweaks.
- Fix `<head>` elements:
    - `<title>`: was "Home | Terragraph", now "Terragraph"
    - `<meta property="og:title">`: was "Home | Terragraph", now "Terragraph"
- Move "Whitepapers" from navbar into the "Docs" dropdown

## Test Plan

<!--
Describe how you have tested your changes.
Please include relevant environment details, logs, screenshots, etc.
Do not provide customer information that could be considered personally identifiable information (PII).
-->

Preview in Docusaurus.