### PR TITLE
feat(docusaurus): add algolia search bar

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -76,6 +76,11 @@ const config = {
       },
       hideableSidebar: true,
       image: 'logo/terragraph-logo-full-RGB.png',
+      algolia: {
+        appId: 'TB9T0CGM6Y',
+        apiKey: 'c60c33d83f465d9ec428517c9f9f9ead',
+        indexName: 'terragraph',
+      },
       navbar: {
         logo: {
           alt: 'Terragraph Logo',


### PR DESCRIPTION
Signed-off-by: Frank Li <frankli1@fb.com>

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Add Algolia DocSearch bar to website in the far right of the nav bar. This is a free service for any open-source project with easy integration in Docusaurus, and it matches all the existing themes. Crawls are scheduled to run once a week, and can be manually triggered as well. See [Docusaurus guide](https://docusaurus.io/docs/search#using-algolia-docsearch) for more details.

Note that the API key used is the Search API Key: "This is the public API key which can be safely used in your frontend code. This key is usable for search queries and it's also able to list the indices you've got access to." There may be a warning from GitGuardian about this key being an exposed secret, but it is okay to use.

## Test Plan

Run Docusaurus website locally. Search bar is added, and search functionality works.
