### PR TITLE
misc: improve Meta-internal build setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,5 @@ cmake-build-release
 # Meta-specific files/dirs
 /facebook/*
 !/facebook/conf
-/facebook.2
+!/facebook/workaround-bin
+/facebook.enabled

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ ENV/
 # dependecy repos
 yocto/meta-openembedded
 yocto/poky
+yocto/source_mirrors
 
 # CLion
 .DS_Store
@@ -86,3 +87,8 @@ cmake-build-release
 
 # watchman cookies
 .watchman-cookie*
+
+# Meta-specific files/dirs
+/facebook/*
+!/facebook/conf
+/facebook.2

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ complete Yocto image.
 
 Building complete Yocto images from scratch can be time-consuming. It is
 recommended that you set up a rather beefy machine or server with a flash
-storage device for clean builds.
+storage device for clean builds. To greatly reduce disk usage requirements
+during builds, add `INHERIT += "rm_work"` to `conf/local.conf` in the build
+directory.
 
 The Yocto Project's [Quick Start Guide] covers how to set up a machine for
 various platforms. Several Meta components require C++17 support and require a

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Pick up a Facebook specific site.conf that defines
 # variables only useful within facebook
 # such as where the SSTATE cache is located.
-BBPATH .= ":${LAYERDIR}/facebook.2"
+BBPATH .= ":${LAYERDIR}/facebook.enabled"
 
 # recipes can find top level directory with this yocto var
 META_TERRAGRAPH_DIR := "${LAYERDIR}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -4,7 +4,7 @@ BBPATH .= ":${LAYERDIR}"
 # Pick up a Facebook specific site.conf that defines
 # variables only useful within facebook
 # such as where the SSTATE cache is located.
-BBPATH .= ":${LAYERDIR}/facebook"
+BBPATH .= ":${LAYERDIR}/facebook.2"
 
 # recipes can find top level directory with this yocto var
 META_TERRAGRAPH_DIR := "${LAYERDIR}"

--- a/facebook/conf/allow-all-networks.conf
+++ b/facebook/conf/allow-all-networks.conf
@@ -1,0 +1,10 @@
+# By default network access for bitbake is limited to facebook.com
+# and everything is picked up via source_mirrors.  When building
+# source mirrors it is convenient to allow outside access via:
+# bitbake -R ../facebook/conf/allow-all-networks.conf <target>
+# Note that this still requires proxying all the things.
+BB_ALLOWED_NETWORKS = ""
+
+# Save local tarballs for all packages we download.
+# These can be used to update our mirror directory.
+BB_GENERATE_MIRROR_TARBALLS = "1"

--- a/facebook/conf/release.conf
+++ b/facebook/conf/release.conf
@@ -1,0 +1,4 @@
+# Inherit fbvuln to do Vulnerability management
+# This breaks SSTATE or it would always be done.
+INHERIT += "fbvuln-manifest"
+CPE_TARGET_SW ?= "linux_kernel"

--- a/facebook/conf/site.conf
+++ b/facebook/conf/site.conf
@@ -1,0 +1,23 @@
+# Set who build this in the various versions.  For external builds
+# this is empty by default but could be set to the company name that
+# built the external build.
+
+# Note that a following space is required if this string is not empty,
+# for instance VENDOR_ID = "Foo Inc "
+VENDOR_ID = "Facebook "
+
+# The following setting will prevent bitbake from downloading anything
+# over the network for internal facebook builds.  Instead we get
+# everything from a local mirror.
+BB_ALLOWED_NETWORKS ?= "*.facebook.com"
+
+# Disable explicit connectivity checking as we aren't usually connected
+# to anything non-facebook.  Also it takes an obnoxiously long time to
+# fail if proxies are not set correctly rather than just quickly failing
+# on the first package download.
+CONNECTIVITY_CHECK_URIS = ""
+
+# Using clang external to Yocto is currently broken.  Disable it for now.
+ENABLE_CLANG_ANALYZE = "0"
+
+INHERIT += "sync_yocto_check"

--- a/facebook/workaround-bin/git
+++ b/facebook/workaround-bin/git
@@ -1,0 +1,10 @@
+#!/bin/bash
+# libpseudo can cause a recursive call to malloc() when initializing
+# jemalloc.  Pseudo isn't needed for git commands, so prevent it from
+# being loaded and then hand off to real git.
+#
+# It's not enough to clear LD_PRELOAD to disable pseudo, as pseudo
+# intercepts the execve() syscall in the shell and will re-enter LD_PRELOAD
+# into the environment if it's missing.  PSEUDO_UNLOAD must be used instead.
+export PSEUDO_UNLOAD=1
+exec /usr/bin/git "$@"

--- a/tg-init-build-env
+++ b/tg-init-build-env
@@ -52,9 +52,9 @@ else
     echo "Neither ${ABS_OEROOT}/$1 nor ${ABS_OEROOT}/meta-$1 exists"
     return 1
 fi
-    
-if [ -d "facebook/workaround-bin" ]; then
-    PATH="$(realpath facebook/workaround-bin):$PATH"
+
+if [ -d "${ABS_OEROOT}/facebook.enabled/workaround-bin" ]; then
+    PATH="$(realpath ${ABS_OEROOT}/facebook.enabled/workaround-bin):$PATH"
 fi
 
 export TEMPLATECONF

--- a/utils/make_builds.sh
+++ b/utils/make_builds.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 ABS_OEROOT="$(dirname "$(dirname "$(realpath "$0")")")"
-# shellcheck disable=SC1091
-source /opt/rh/devtoolset-7/enable
 # shellcheck disable=SC1090
 source "$ABS_OEROOT/utils/check_build_ver.sh"
 
@@ -10,8 +8,6 @@ if [ "$1" == "--allow-all-networks" ];
 then
   echo "Allowing bitbake to access all networks"
   EXTRA_BITBAKE_ARGS="-R $ABS_OEROOT/facebook/conf/allow-all-networks.conf"
-  # shellcheck disable=SC1090
-  source "$ABS_OEROOT/facebook/utils/fb-proxy-settings.sh"
 fi
 
 echo ----

--- a/utils/sync_yocto_utils.sh
+++ b/utils/sync_yocto_utils.sh
@@ -42,8 +42,8 @@ sync_yocto() {
     mkdir -v ./yocto/source_mirrors
   fi
 
-  # On Meta-internal servers, also install "facebook.2" symlink to "facebook"
-  if [ -d "$SOURCE_MIRRORS_DIR" ] && [ ! -e ./facebook.2 ]; then
-    ln -v -s ./facebook ./facebook.2
+  # On Meta-internal servers, also install "facebook.enabled" symlink
+  if [ -d "$SOURCE_MIRRORS_DIR" ] && [ ! -e ./facebook.enabled ]; then
+    ln -v -s ./facebook ./facebook.enabled
   fi
 }

--- a/utils/sync_yocto_utils.sh
+++ b/utils/sync_yocto_utils.sh
@@ -4,6 +4,9 @@ POKY_COMMIT="bba323389749ec3e306509f8fb12649f031be152"
 OE_COMMIT="ec978232732edbdd875ac367b5a9c04b881f2e19"
 BRANCH="dunfell"
 
+# Meta-internal source_mirrors location, change this as needed
+SOURCE_MIRRORS_DIR="/mnt/gvfs/yocto/source_mirrors/04d5c868a31bbd7ea0a0795aeb65acf2202e8008"
+
 sync_yocto() {
   POKY_REPO_URI=$1
   OE_REPO_URI=$2
@@ -27,8 +30,20 @@ sync_yocto() {
   git clone -b "${BRANCH}" "${OE_REPO_URI}" yocto/meta-openembedded
   (cd yocto/meta-openembedded && git reset --hard "${OE_COMMIT}")
 
-  # Make a blank source_mirrors for any extra blobs required
+  # Make source_mirrors for any extra blobs required.
+  # If $SOURCE_MIRRORS_DIR exists, symlink to it, otherwise create an empty dir.
+  if [ -L ./yocto/source_mirrors ]; then
+    rm -v ./yocto/source_mirrors
+  fi
+  if [ -d "$SOURCE_MIRRORS_DIR" ]; then
+    ln -v -s "$SOURCE_MIRRORS_DIR" ./yocto/source_mirrors
+  fi
   if [ ! -e ./yocto/source_mirrors ]; then
-    mkdir ./yocto/source_mirrors
+    mkdir -v ./yocto/source_mirrors
+  fi
+
+  # On Meta-internal servers, also install "facebook.2" symlink to "facebook"
+  if [ -d "$SOURCE_MIRRORS_DIR" ] && [ ! -e ./facebook.2 ]; then
+    ln -v -s ./facebook ./facebook.2
   fi
 }


### PR DESCRIPTION
Signed-off-by: Jeffrey Han <39203126+elludraon@users.noreply.github.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

<!--
Describe your changes, or link to another Issue or Pull Request.
-->
Some changes to simplify Meta-internal builds in this repository:
- Hardcode the GVFS source mirrors path in `utils/sync_yocto_utils.sh` (called by `./sync_yocto.sh`) and create the `yocto/source_mirrors` symlink if the path exists.
- Add `facebook/conf/` directory containing Meta-specific conf files. Update BBPATH in `conf/layer.conf` to include `facebook.enabled` instead of `facebook`, and create a symlink to `facebook.enabled` in `sync_yocto_utils.sh` while creating the source_mirrors link. (This conflates the two features, but will have to do for now.)
- Add `facebook/workaround-bin/git` to resolve internal build issues.
- Update `.gitignore`.

## Test Plan

<!--
Describe how you have tested your changes.
Please include relevant environment details, logs, screenshots, etc.
Do not provide customer information that could be considered personally identifiable information (PII).
-->
bitbake images without needing extra steps.
