### PR TITLE
kill of stuck vpp_chaperone instance upon vpp restart

### DIFF
--- a/meta-qoriq/recipes-facebook/tg-vpp/files/etc/sv/vpp/vpp.run
+++ b/meta-qoriq/recipes-facebook/tg-vpp/files/etc/sv/vpp/vpp.run
@@ -45,6 +45,12 @@ fi
 # vpp instance, it will not respond to other signals.
 killall -9 fib_vpp
 
+while /bin/pidof vpp_chaperone; do
+  echo "attempt to kill concurrent vpp_chaperone..."
+  /usr/bin/killall vpp_chaperone
+  sleep 0.5
+done
+
 echo "Starting vpp_chaperone..."
 sv once vpp_chaperone
 

--- a/meta-qoriq/recipes-facebook/tg-vpp/files/etc/sv/vpp/vpp.run
+++ b/meta-qoriq/recipes-facebook/tg-vpp/files/etc/sv/vpp/vpp.run
@@ -45,9 +45,9 @@ fi
 # vpp instance, it will not respond to other signals.
 killall -9 fib_vpp
 
-while /bin/pidof vpp_chaperone; do
+while pidof vpp_chaperone; do
   echo "attempt to kill concurrent vpp_chaperone..."
-  /usr/bin/killall vpp_chaperone
+  killall vpp_chaperone
   sleep 0.5
 done
 


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

In some rare cases (multipoint setup with at least 4 links) vpp_chaperone might connect to vpp control socket right before vpp restarts (due to POP config changes need to be applied to a certain set of config files). this results the process to get stuck there, and the necessary configuration changes are not propagated into vpp anymore. The fix makes sure if there's an active vpp_chaperone instance whenever vpp is restarted, it will be stopped by a SIGTERM signal.

## Test Plan

(sorry, a pretty unintuitive+headstrong test follows) Set up a small network with at least 4-5 nodes in a PMP setup, wait for all links to come up and the network settle in a steady state. Test node reachability with pingL all nodes should respond. Reboot the POP node (which is where all other nodes connect). repeat. there should be no long (>3 min) outages in the connectivity. If the issue surfaces, the connecting nodes will not be reachable from the outside.
