### PR TITLE
Add build-terragraph-image-x86 GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build-terragraph-image-x86.yml
+++ b/.github/workflows/build-terragraph-image-x86.yml
@@ -1,0 +1,30 @@
+name: Build terragraph-image-x86
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: [self-hosted, yocto]
+    steps:   
+    - name: Run Configuration Script
+      run: sudo bash /home/ubuntu/on_run.sh
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Sync Yocto
+      run: bash sync_yocto.sh
+    - name: Update Source Mirrors
+      run: rm -r yocto/source_mirrors ; ln -s /home/ubuntu/source_mirrors yocto/source_mirrors
+    # Reduce the resources Yocto uses to prevent out-of-memory failures.
+    - name: Configure Build 
+      run:
+        source tg-init-build-env meta-x86 build-x86 &&
+        sed -i "s/\${@oe.utils.cpu_count()}/\${@oe.utils.cpu_count() \/\/ 2}/g" conf/local.conf &&
+        sed -i "s/PARALLEL_MAKE.*/PARALLEL_MAKE = \"-j 8\"/g" conf/local.conf
+    - name: Link sstate-cache
+      run: mkdir -p /home/ubuntu/sstate-cache ; mkdir -p build-x86 ; ln -s /home/ubuntu/sstate-cache build-x86/sstate-cache
+    - name: Build Image
+      run: source tg-init-build-env meta-x86 build-x86 && USER=meta bitbake terragraph-image-x86


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Add a GitHub Actions workflow to build the terragraph-image-x86 meta-terragraph target. The workflow triggers upon pushes to the main branch. The workflow only runs on self-hosted runners managed by Meta.

## Test Plan

See a similar workflow run on the `develop` branch of this repository: 
https://github.com/terragraph/meta-terragraph/runs/7363982253?check_suite_focus=true
