### PR TITLE
fix(lua): fix tg_frr_utils_test.lua

### DIFF
--- a/src/terragraph-e2e/lua/tests/tg_frr_utils_test.lua
+++ b/src/terragraph-e2e/lua/tests/tg_frr_utils_test.lua
@@ -52,6 +52,7 @@ function TestMain:test_getNodeBgpInfo()
   local expectedBgpParams = {
     keepalive = 30,
     localAsn = 65075,
+    md5Password = "",
     nextHop = "2001::3",
     routerId = "79.227.243.230"
   }
@@ -180,6 +181,9 @@ function TestMain:test_fillConfigTemplate()
 router bgp 65075
  bgp router-id 79.227.243.230
  no bgp default ipv4-unicast
+ bgp deterministic-med
+ bgp bestpath as-path multipath-relax
+ bgp log-neighbor-changes
  no bgp network import-check
 
  neighbor 2620:10d:c0be:902b::2 remote-as 65074
@@ -188,6 +192,8 @@ router bgp 65075
  timers bgp 30 90
 
  address-family ipv6 unicast
+  maximum-paths 2
+  maximum-paths ibgp 2
   network 1001:1001::/55
   network 2001::/56
   network 3001:0:0:8000::/57


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

Fix failing `tg_frr_utils_test.lua` as the unit test was not updated after PR #1.

## Test Plan

```
=====================================
Running Test: /usr/sbin/tests/lua/tg_frr_utils_test.lua
=====================================

Started on Fri Jul 22 22:24:53 2022
    TestMain.test_computeRouterId ... Ok
    TestMain.test_fillConfigTemplate ... Ok
    TestMain.test_getNodeBgpInfo ... The nodeConfig table is invalid
The nodeConfig table is invalid
Missing 'bgpParams' structure in node config
Ok
    TestMain.test_readBgpParams ... Invalid bgpParams or popParams struct
Invalid bgpParams or popParams struct
Ok
    TestMain.test_readNeighbors ... Invalid bgpParams struct
Invalid bgpParams struct
Invalid IPv6 address '10.0.0.1' for neighbor 1
Ok
    TestMain.test_readTgPrefixesFromNodeConfig ... Invalid prefix found: 1234::/1234
Ok
=========================================================
Ran 6 tests in 0.002 seconds, 6 successes, 0 failures
OK
```
