### PR TITLE
fix(openr): fix platform_linux crashing on startup

### DIFF
--- a/recipes-facebook/openr/files/sv/fib_linux.run
+++ b/recipes-facebook/openr/files/sv/fib_linux.run
@@ -40,14 +40,6 @@ fi
 # enable forwarding
 sysctl -w net.ipv6.conf.all.forwarding=1
 
-# Explicitly disable netlink-system-handler as Open/R has it enabled
-# Set platform-pub-url to non default value so that Open/R & platform_linux
-# don't bind on same URL. Ideally platform-pub-url shouldn't be binded if
-# netlink-system-handler is disabled.
-exec /usr/sbin/platform_linux \
---platform_pub_url="ipc:///tmp/linux-platform-pub-url" \
---v 1 \
--logtostderr \
-2>&1
+exec /usr/sbin/platform_linux -v 1 -logtostderr 2>&1
 
 done

--- a/recipes-support/openr/files/fix-platform-linux-handler.patch
+++ b/recipes-support/openr/files/fix-platform-linux-handler.patch
@@ -1,0 +1,13 @@
+diff --git a/openr/platform/LinuxPlatformMain.cpp b/openr/platform/LinuxPlatformMain.cpp
+index 97ea1fb46..0cf4c1d01 100644
+--- a/openr/platform/LinuxPlatformMain.cpp
++++ b/openr/platform/LinuxPlatformMain.cpp
+@@ -29,9 +29,6 @@ main(int argc, char** argv) {
+
+   folly::EventBase mainEvb;
+   openr::EventBaseStopSignalHandler handler(&mainEvb);
+-  handler.registerSignalHandler(SIGINT);
+-  handler.registerSignalHandler(SIGQUIT);
+-  handler.registerSignalHandler(SIGTERM);
+
+   std::vector<std::thread> allThreads{};

--- a/recipes-support/openr/openr_src.inc
+++ b/recipes-support/openr/openr_src.inc
@@ -1,2 +1,4 @@
 SRCREV = "f1f5c30d6905f5a4b0be28d52c2136643e6413a8"
-SRC_URI = "git://github.com/facebook/openr.git;protocol=https;branch=tg-M80.1"
+SRC_URI = "git://github.com/facebook/openr.git;protocol=https;branch=tg-M80.1 \
+           file://fix-platform-linux-handler.patch \
+          "


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

<!--
Describe your changes, or link to another Issue or Pull Request.
-->
`platform_linux` was crashing on startup due to 2 issues:
- gflag `--platform_pub_url` no longer exists, removed in https://github.com/facebook/openr/commit/efd1360a8a8b812ac0eea491b38f5637205ac833
- `openr::EventBaseStopSignalHandler` was registering signal handlers twice, patch to delete the duplicate calls

## Test Plan

<!--
Describe how you have tested your changes.
Please include relevant environment details, logs, screenshots, etc.
Do not provide customer information that could be considered personally identifiable information (PII).
-->
See `/var/log/fib_linux/current`, program is no longer crashing:
```
I0726 23:00:59.029499 17369 LinuxPlatformMain.cpp:41] Starting NetlinkProtolSocketEvl thread...
I0726 23:00:59.030074 17369 NetlinkProtocolSocket.cpp:140] Created netlink socket. fd=12, port=0
I0726 23:00:59.030937 17356 LinuxPlatformMain.cpp:66] Main event loop starting...
I0726 23:00:59.031100 17375 LinuxPlatformMain.cpp:60] Fib Agent starting...
I0726 23:00:59.031412 17375 ThriftServer.cpp:403] libevent 2.1.11-stable method epoll
I0726 23:00:59.031952 17369 NetlinkProtocolSocket.cpp:146] Registering netlink socket fd 12 with EventBase for read events
I0726 23:00:59.428313 17385 Cpp2Connection.cpp:283] ERROR: Task killed: Rocket upgrade disabled: ::1
I0726 23:01:00.548963 17382 NetlinkFibHandler.cpp:193] Syncing unicast FIB for client OPENR, numRoutes=0
```
