### PR TITLE
Add tests step to build-terragraph-image-x86 GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build-terragraph-image-x86.yml
+++ b/.github/workflows/build-terragraph-image-x86.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: [self-hosted, yocto]
     if: github.repository_owner == 'terragraph'
-    steps:   
+    steps:
     - name: Run Configuration Script
       run: sudo bash /home/ubuntu/on_run.sh
     - uses: actions/checkout@v2
@@ -20,12 +20,39 @@ jobs:
     - name: Update Source Mirrors
       run: rm -r yocto/source_mirrors ; ln -s /home/ubuntu/source_mirrors yocto/source_mirrors
     # Reduce the resources Yocto uses to prevent out-of-memory failures.
-    - name: Configure Build 
+    - name: Configure Build
       run:
         source tg-init-build-env meta-x86 build-x86 &&
         sed -i "s/\${@oe.utils.cpu_count()}/\${@oe.utils.cpu_count() \/\/ 2}/g" conf/local.conf &&
-        sed -i "s/PARALLEL_MAKE.*/PARALLEL_MAKE = \"-j 8\"/g" conf/local.conf
+        sed -i "s/PARALLEL_MAKE.*/PARALLEL_MAKE = \"-j 8\"/g" conf/local.conf &&
+        echo "INHERIT += \"rm_work\"" >> conf/local.conf
     - name: Link sstate-cache
       run: mkdir -p /home/ubuntu/sstate-cache ; mkdir -p build-x86 ; ln -s /home/ubuntu/sstate-cache build-x86/sstate-cache
     - name: Build Image
       run: source tg-init-build-env meta-x86 build-x86 && USER=meta bitbake terragraph-image-x86
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: rootfsx86
+        path: build-x86/tmp/deploy/images/tgx86/terragraph-image-x86-tgx86.tar.gz
+        retention-days: 3
+  tests:
+    runs-on: [self-hosted, yocto]
+    needs: build
+    steps:
+    - name: Download rootfs
+      uses: actions/download-artifact@v3
+      with:
+        name: rootfsx86
+        path: /tmp/
+    - name: Create rootfs
+      run: |
+        sudo rm -rf /tmp/rootfs
+        mkdir /tmp/rootfs
+        cd /tmp/rootfs
+        tar -xf /tmp/terragraph-image-x86-tgx86.tar.gz
+    - name: Exclude update_firewall
+      run: rm /tmp/rootfs/usr/bin/update_firewall
+    - name: Run Tests
+      run: |
+        sudo chroot /tmp/rootfs /bin/bash /usr/sbin/run_tests.sh


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

## Description

Add a `tests` job for running the tests shipped with the x86 build. The tests are stored under `/usr/sbin/tests` in the x86 rootfs. All the tests under this directory are executed by the `tests` job.

The `tests` job deletes `update_firewall` because this utility does not work when `chroot`ing into the x86 rootfs, and `update_firewall` is not expected to work in the x86 test environment.

Also clean-up some whitespace in `build-terragraph-image-x86.yml` and add `rm_work` to the build workflow.

## Test Plan

[An example of this workflow failing](https://github.com/terragraph/meta-terragraph/runs/7640926519?check_suite_focus=true). This failure is expected because update_firewall is not disabled.

[An example of this workflow succeeding.](https://github.com/terragraph/meta-terragraph/actions/runs/2785335948)
