### PR TITLE
Automatically publish e2e-controller container to the GitHub Container Repository

### DIFF
--- a/.github/workflows/build-terragraph-image-x86.yml
+++ b/.github/workflows/build-terragraph-image-x86.yml
@@ -54,5 +54,30 @@ jobs:
     - name: Exclude update_firewall
       run: rm /tmp/rootfs/usr/bin/update_firewall
     - name: Run Tests
+      run: sudo chroot /tmp/rootfs /bin/bash /usr/sbin/run_tests.sh
+  publish:
+    env:
+      REG: ghcr.io/terragraph
+      IMAGE: e2e-controller
+      TAG: latest
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download rootfs
+      uses: actions/download-artifact@v3
+      with:
+        name: rootfsx86
+        path: /tmp/
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REG }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build and push Docker image
       run: |
-        sudo chroot /tmp/rootfs /bin/bash /usr/sbin/run_tests.sh
+        docker import /tmp/terragraph-image-x86-tgx86.tar.gz "$REG/$IMAGE:$TAG"
+        docker push "$REG/$IMAGE:$TAG"


### PR DESCRIPTION
## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.


## Description

Upon completion of the `tests` step of the x86 workflow, publish the e2e-controller docker image to the Github Container Repository (GHCR.)

## Test Plan

https://github.com/terragraph/meta-terragraph/actions/runs/2786261048
