### PR TITLE
Update cache on netlink error

### DIFF
--- a/recipes-support/openr/files/0001-fix-openr-update-interface-index-cache-on-netlink-er.patch
+++ b/recipes-support/openr/files/0001-fix-openr-update-interface-index-cache-on-netlink-er.patch
@@ -33,10 +33,10 @@ index 8d6eddb11..6c7b1cae4 100644
    return rtBuilder.setValid(true).build();
  }
  
-+void NetlinkFibHandler::checkIfIndex(int ifIndex){
++void NetlinkFibHandler::checkIfIndex(const int ifIndex){
 +    char indexName[IF_NAMESIZE];
 +    if(if_indextoname(ifIndex, indexName)==NULL){
-+        XLOG(INFO) << "ifIndex "<< ifIndex<< " is invalid, setting flag to reload ifIndex cache on next request";
++        XLOG(INFO) << "ifIndex " << ifIndex << " is invalid, setting flag to reload ifIndex cache on next request";
 +        cacheInvalid = true;
 +    }
 +}
@@ -69,7 +69,7 @@ index fe7cd19b9..a339412e9 100644
 +   * Test if ifindex returned by cache is valid or not,
 +   * if invalid we set a flag and on next request update cache
 +   */
-+   void checkIfIndex(int ifIndex);
++   void checkIfIndex(const int ifIndex);
 +   bool cacheInvalid;
  };
  

--- a/recipes-support/openr/files/0001-fix-openr-update-interface-index-cache-on-netlink-er.patch
+++ b/recipes-support/openr/files/0001-fix-openr-update-interface-index-cache-on-netlink-er.patch
@@ -1,0 +1,79 @@
+From dd3232d44e96c899c1af40206c319c97fdc4ed2d Mon Sep 17 00:00:00 2001
+From: Chitrang Srivastava <chitrang.srivastava@cambiumnetworks.com>
+Date: Thu, 15 Sep 2022 10:31:51 +0530
+Subject: [PATCH] fix(openr): update interface index cache on netlink error
+
+---
+ openr/platform/NetlinkFibHandler.cpp | 16 ++++++++++++++++
+ openr/platform/NetlinkFibHandler.h   |  7 +++++++
+ 2 files changed, 23 insertions(+)
+
+diff --git a/openr/platform/NetlinkFibHandler.cpp b/openr/platform/NetlinkFibHandler.cpp
+index 8d6eddb11..6c7b1cae4 100644
+--- a/openr/platform/NetlinkFibHandler.cpp
++++ b/openr/platform/NetlinkFibHandler.cpp
+@@ -13,6 +13,8 @@
+ #include <openr/if/gen-cpp2/Platform_constants.h>
+ #include <openr/platform/NetlinkFibHandler.h>
+ 
++#include <net/if.h>
++
+ namespace openr {
+ 
+ namespace {
+@@ -37,6 +39,7 @@ createSemiFutureWithClientIdError() {
+ NetlinkFibHandler::NetlinkFibHandler(fbnl::NetlinkProtocolSocket* nlSock)
+     : facebook::fb303::BaseService("openr"),
+       nlSock_(nlSock),
++      cacheInvalid(false),
+       startTime_(std::chrono::duration_cast<std::chrono::seconds>(
+                      std::chrono::system_clock::now().time_since_epoch())
+                      .count()) {
+@@ -546,13 +549,26 @@ NetlinkFibHandler::buildMplsRoute(
+   return rtBuilder.setValid(true).build();
+ }
+ 
++void NetlinkFibHandler::checkIfIndex(int ifIndex){
++    char indexName[IF_NAMESIZE];
++    if(if_indextoname(ifIndex, indexName)==NULL){
++        XLOG(INFO) << "ifIndex "<< ifIndex<< " is invalid, setting flag to reload ifIndex cache on next request";
++        cacheInvalid = true;
++    }
++}
++
+ std::optional<int>
+ NetlinkFibHandler::getIfIndex(const std::string& ifName) {
++  if(cacheInvalid){
++      initializeInterfaceCache();
++      cacheInvalid = false;
++  }
+   // Lambda function to lookup ifName in cache
+   auto getCachedIndex = [this, &ifName]() -> std::optional<int> {
+     auto cache = ifNameToIndex_.rlock();
+     auto it = cache->find(ifName);
+     if (it != cache->end()) {
++      checkIfIndex(it->second);
+       return it->second;
+     }
+     return std::nullopt;
+diff --git a/openr/platform/NetlinkFibHandler.h b/openr/platform/NetlinkFibHandler.h
+index fe7cd19b9..a339412e9 100644
+--- a/openr/platform/NetlinkFibHandler.h
++++ b/openr/platform/NetlinkFibHandler.h
+@@ -190,6 +190,13 @@ class NetlinkFibHandler : public thrift::FibServiceSvIf,
+ 
+   // Time when service started, in number of seconds, since epoch
+   const int64_t startTime_{0};
++
++  /*
++   * Test if ifindex returned by cache is valid or not,
++   * if invalid we set a flag and on next request update cache
++   */
++   void checkIfIndex(int ifIndex);
++   bool cacheInvalid;
+ };
+ 
+ } // namespace openr
+-- 
+2.17.1
+

--- a/recipes-support/openr/openr_src.inc
+++ b/recipes-support/openr/openr_src.inc
@@ -1,2 +1,4 @@
 SRCREV = "fc15cfa5d2da9bc2a6d55409ec40bcc95f44006c"
-SRC_URI = "git://github.com/facebook/openr.git;protocol=https;branch=tg-M80.1"
+SRC_URI = "git://github.com/facebook/openr.git;protocol=https;branch=tg-M80.1 \
+           file://0001-fix-openr-update-interface-index-cache-on-netlink-er.patch \
+          "


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

fib_linux was throwing netlink error when e2e_minion is restarted.
```
I0904 17:23:13.605388 24895 NetlinkFibHandler.cpp:105] Adding/Updating unicast routes of client OPENR, numRoutes=5
E0904 17:23:13.609419 24882 NetlinkProtocolSocket.cpp:171] Netlink request error for seq=350, retval=-19
E0904 17:23:13.610333 24882 NetlinkProtocolSocket.cpp:171] Netlink request error for seq=352, retval=-19
E0904 17:23:13.611045 24882 NetlinkProtocolSocket.cpp:171] Netlink request error for seq=354, retval=-19
E0904 17:23:13.611716 24882 NetlinkProtocolSocket.cpp:171] Netlink request error for seq=356, retval=-19
E0904 17:23:13.612370 24882 NetlinkProtocolSocket.cpp:171] Netlink request error for seq=358, retval=-19
```
#### Root Cause
When openr recevied a prefix on any interface , it ask fib to program a route for this.
Here fib_linux uses netlink to program route in Linux.
platform_linux convert interface name to interface index, this is done through a cache which is initialized at startup.
Now when e2e_minion is restarted terra interfaces are recreated and hence there interface index are changed and platform_linux didnt updated its cache to send netlink mesage to updated index.
Thats the reason we see error in netlink.

#### Fix
if netlink reports error , set a flag to reload interface index cache on next requtest
logs after fix
```
I0913 02:07:51.510177 30302 NetlinkFibHandler.cpp:128] Deleting unicast routes of client OPENR, numRoutes=5
I0913 02:08:16.183758 30302 NetlinkFibHandler.cpp:108] Adding/Updating unicast routes of client OPENR, numRoutes=5
I0913 02:08:16.184090 30302 NetlinkFibHandler.cpp:555] ifIndex 101 is invalid, setting flag to reload ifIndex cache on next request
E0913 02:08:16.188894 30288 NetlinkProtocolSocket.cpp:171] Netlink request error for seq=15, retval=-19
E0913 02:08:16.253119 30305 service_tcc.h:132] openr::fbnl::NlException: Error(19) - No such device. One or more netlink request failed  in function addUnicas
I0913 02:08:16.261253 30305 Cpp2Connection.cpp:283] ERROR: Task killed: Rocket upgrade disabled: ::1
I0913 02:08:16.264134 30302 NetlinkFibHandler.cpp:108] Adding/Updating unicast routes of client OPENR, numRoutes=5
```

## Test Plan

1. restart e2e_minion
2. reboot node
3. bring the link down
4. reboot POP node