### PR TITLE
fix(wil6210): handle event 0x1a23

### DIFF
--- a/meta-qca/recipes-radio/wigig-dpdk/files/0005-wil6210-dpdk-driver-log-message-lower-priority.patch
+++ b/meta-qca/recipes-radio/wigig-dpdk/files/0005-wil6210-dpdk-driver-log-message-lower-priority.patch
@@ -1,0 +1,12 @@
+diff --git a/dpdk/drivers/wil6210/wil6210_wmi.c b/dpdk/drivers/wil6210/wil6210_wmi.c
+index 4417c1a..daef9ac 100644
+--- a/dpdk/drivers/wil6210/wil6210_wmi.c
++++ b/dpdk/drivers/wil6210/wil6210_wmi.c
+@@ -2275,6 +2275,7 @@ static const struct {
+ 	{WMI_TDM_DISCONNECT_EVENTID,		wmi_evt_tdm_disconnect},
+ 	{WMI_TDM_CHANNEL_CONFIG_EVENTID,	wmi_evt_tdm_channel_config},
+ 	{WMI_INTERNAL_FW_QUEUE_STATS_EVENTID, 	wmi_evt_internal_fw_queue_stats},
++	{WMI_PMC_EXT_EVENTID,                   wmi_evt_ignore},
+ };
+ 
+ static void wmi_complete(struct wil6210_priv *wil)

--- a/meta-qca/recipes-radio/wigig-dpdk/wigig-dpdk_git.bb
+++ b/meta-qca/recipes-radio/wigig-dpdk/wigig-dpdk_git.bb
@@ -10,6 +10,7 @@ DEPENDS += "libnl"
 
 SRC_URI += "file://0003-wil6210-dpdk-add-missing-mutex_lock-call-in-wil_slav.patch \
             file://0004-wil6210-dpdk-Upgrade-to-DPDK-20.11.2.patch \
+            file://0005-wil6210-dpdk-driver-log-message-lower-priority.patch \
             "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Signed-off-by: Kapil Shukla <kapil.a.shukla@capgemini.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [ ] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [ ] If this is a non-trivial change, I have already opened an accompanying Issue.
- [ ] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

wil6210-dpdk-driver-log-message-lower-priority-issue-fix.
Unhandled event 0x1a23 issue fixed.

## Test Plan

Tested on PUMA. 
