### PR TITLE
fix(VPP): VPP-Version-String-Improvements(vpp v21.01.0-(v21.08-lsdk)...)

### DIFF
--- a/meta-qoriq/recipes-extended/vpp/files/0048-VPP-Displayed-Version-String-Improvements-Fix.patch
+++ b/meta-qoriq/recipes-extended/vpp/files/0048-VPP-Displayed-Version-String-Improvements-Fix.patch
@@ -1,0 +1,43 @@
+From ffae88d47e7e4c979d504adc031aab8767b32239 Mon Sep 17 00:00:00 2001
+From: Kapil Shukla <kapil.a.shukla@capgemini.com>
+Date: Thu, 3 Nov 2022 12:58:17 +0530
+Subject: [PATCH] VPP-Displayed-Version-String-Improvements-Fix
+
+Signed-off-by: Kapil Shukla <kapil.a.shukla@capgemini.com>
+---
+ src/scripts/version | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/scripts/version b/src/scripts/version
+index 1c265bff6..73e666d78 100755
+--- a/src/scripts/version
++++ b/src/scripts/version
+@@ -19,16 +19,22 @@ cd "$path"
+ 
+ if [ -f .version ]; then
+     vstring=$(cat .version)
++TAG=$(echo ${vstring} | cut -d ' ' -f1 | sed -e 's/^v//')
++ADD=$(echo ${vstring} | cut -s -d ' ' -f2)
++POINT=$(echo ${TAG} | cut -d. -f3)
+ else
+     vstring=$(git describe --long)
++TAG=$(echo ${vstring} | cut -d- -f1 | sed -e 's/^v//')
++ADD=$(echo ${vstring} | cut -s -d- -f2)
++POINT=$(echo ${TAG} | cut -d. -f3)
+     if [ $? != 0 ]; then
+       exit 1
+     fi
+ fi
+ 
+-TAG=$(echo ${vstring} | cut -d- -f1 | sed -e 's/^v//')
+-ADD=$(echo ${vstring} | cut -s -d- -f2)
+-POINT=$(echo ${TAG} | cut -d. -f3)
++#TAG=$(echo ${vstring} | cut -d- -f1 | sed -e 's/^v//')
++#ADD=$(echo ${vstring} | cut -s -d- -f2)
++#POINT=$(echo ${TAG} | cut -d. -f3)
+ 
+ # during make pkg-rpm vstring ends up being vXX.YY, which is not what we expect. Fix it up.
+ if [ -z "${ADD}" ]; then
+-- 
+2.25.1
+

--- a/meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb
+++ b/meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb
@@ -54,6 +54,7 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/vpp;proto
            file://0045-policer-classify-unrecognized-packets-as-default-TC3.patch \
            file://0046-fix-vpp-for-2R3C-policers.patch \
            file://0047-properly-respond-to-solicited-forus-ICMPv6-NS-messag.patch \
+           file://0048-VPP-Displayed-Version-String-Improvements-Fix.patch \
            "
 
 # TGHQoS and TG features that rely on hqos implementation
@@ -160,3 +161,9 @@ FILES_${PN}-dev += " \
 # TARGET_CFLAGS_append = " -DHAS_DVPP_MODULE_HEADER"
 
 BBCLASSEXTEND = "native"
+
+do_vpp_version(){
+    echo "21.01 (v${PV})" > ${S}/scripts/.version
+}
+addtask vpp_version after do_unpack
+do_unpack[postfuncs] += "do_vpp_version"


### PR DESCRIPTION
Signed-off-by: Kapil Shukla <kapil.a.shukla@capgemini.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [ ] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [ ] If this is a non-trivial change, I have already opened an accompanying Issue.
- [ ] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

"VPP dispalyed version string improvements" 
 
Introduced new patch - meta-qoriq/recipes-extended/vpp/files/0048-VPP-Displayed-Version-String-Improvements-Fix.patch
Modified VPP recipe - meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb

## Test Plan

Verified on PUMA as below -

node-34-ef-b6-8a-0e-0e:~# vppctl show version
vpp v21.01.0-(v21.08-lsdk)~g8a1fe03ad built by  on terragraph at 2021-07-19T06:18:04
