### PR TITLE
fix(E2E-Minion):Post-config-action-fix-for-node-topology-name-changes

### DIFF
--- a/recipes-facebook/e2e/e2e-files_0.1.bb
+++ b/recipes-facebook/e2e/e2e-files_0.1.bb
@@ -174,6 +174,7 @@ FILES_${PN}-minion += " \
     /usr/sbin/fb_tg_restart.sh \
     /usr/sbin/hostapd_stop.sh \
     /usr/sbin/start_cpe_security.sh \
+    /usr/sbin/reload_topology_names.sh \
     "
 
 # Controller package

--- a/src/terragraph-e2e/e2e/config/config_metadata.json
+++ b/src/terragraph-e2e/e2e/config/config_metadata.json
@@ -2826,6 +2826,18 @@
       "action": "RESTART_STATS_AGENT",
       "readOnly": true
     },
+    "nodeName": {
+        "desc": "The name of this node",
+        "type": "STRING",
+        "action": "RELOAD_TOPOLOGY_NAMES",
+        "readOnly": true
+    },
+    "topologyName": {
+      "desc": "The name of the topology that this node belongs to",
+      "type": "STRING",
+      "action": "RELOAD_TOPOLOGY_NAMES",
+      "readOnly": true
+     },
     "nodeType": {
       "desc": "The type of this node (1: CN, 2: DN)",
       "type": "INTEGER",

--- a/src/terragraph-e2e/e2e/if/Controller.thrift
+++ b/src/terragraph-e2e/e2e/if/Controller.thrift
@@ -697,6 +697,7 @@ enum CfgAction {
   RELOAD_TUNNEL_CONFIG = 130,
   RELOAD_VPP_CONFIG_AND_MONITOR = 140,
   UPDATE_ZONE = 141,
+  RELOAD_TOPOLOGY_NAMES = 150,
 }
 
 // Config parameter data types

--- a/src/terragraph-e2e/e2e/minion/ConfigApp.cpp
+++ b/src/terragraph-e2e/e2e/minion/ConfigApp.cpp
@@ -116,6 +116,10 @@ const std::string kReloadTunnelCmd("/usr/sbin/config_tunnel.sh");
 // Run vpp_chaperone
 const std::string kRunVppChaperoneCmd(
   "/usr/sbin/run_vpp_chaperone_and_monitor.sh");
+
+// Reload topology names
+const std::string kReloadTopologyNamesCmd("/usr/sbin/reload_topology_names.sh");
+
 }
 
 namespace facebook {
@@ -500,6 +504,10 @@ ConfigApp::performNodeActions(
       case thrift::CfgAction::RELOAD_VPP_CONFIG_AND_MONITOR:
         LOG(INFO) << "Running VPP Chaperone...";
         SysUtils::system(kRunVppChaperoneCmd);
+        break;
+      case thrift::CfgAction::RELOAD_TOPOLOGY_NAMES:
+        LOG(INFO) << "Reload topology names...";
+        SysUtils::system(kReloadTopologyNamesCmd);
         break;
       case thrift::CfgAction::UPDATE_ZONE: {
         auto bgpParams = SharedObjects::getNodeConfigWrapper()->rlock()

--- a/src/terragraph-e2e/scripts/reload_topology_names.sh
+++ b/src/terragraph-e2e/scripts/reload_topology_names.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+sv restart stats_agent
+/usr/bin/fluent-bit restart


### PR DESCRIPTION
Signed-off-by: bmswamy <banala.swamy@capgemini.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [ ] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [ ] If this is a non-trivial change, I have already opened an accompanying Issue.
- [ ] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

E2E-Minion: Post config action fix for node topology name changes 

## Test Plan

**Node topology name change verified on a puma node  with the below command:** 

 config_set -s topologyInfo.nodeName "my-node-123"

 tg2 minion set_node_config
 Request sent

**Verified "stats_agent" and "fluent-bit" services running in a "/var/log/e2e_minion/current" log as mentioned below:**

I1110 06:56:01.600895  3664 ConfigApp.cpp:252] Changed or removed config values:
{"topologyInfo":{"nodeName":"my-node-123"}}
I1110 06:56:01.601145  3664 ConfigApp.cpp:509] Reload topology names...
ok: run: stats_agent: (pid 8541) 1s

Fluent Bit v1.9.1
* Copyright (C) 2015-2021 The Fluent Bit Authors
* Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
* https://fluentbit.io

[2022/11/10 06:56:02] [ info] [fluent bit] version=1.9.1, commit=67b144340b, pid=8547
[2022/11/10 06:56:02] [ info] [storage] version=1.1.6, type=memory-only, sync=normal, checksum=disabled, max_chunks_up=128
[2022/11/10 06:56:02] [ info] [cmetrics] version=0.3.0
[2022/11/10 06:56:02] [ info] [sp] stream processor started
