### PR TITLE
fix(VPP):VPP-Displayed-Version-String-Improvements

### DIFF
--- a/meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
+++ b/meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
@@ -1,0 +1,21 @@
+diff -ruN a/vpp/app/version.c b/vpp/app/version.c
+--- a/vpp/app/version.c	2022-11-11 12:17:52.665882031 +0530
++++ b/vpp/app/version.c	2022-11-11 12:29:15.631962472 +0530
+@@ -29,7 +29,7 @@
+ 
+ /** The image version string */
+ char *vpe_version_string =
+-  "vpp v" VPP_BUILD_VER
++  "vpp v21.01 " "("VPP_BUILD_VER")"
+   " built by " VPP_BUILD_USER " on " VPP_BUILD_HOST " at " VPP_BUILD_DATE;
+ 
+ /** The name of the compiler */
+@@ -74,7 +74,7 @@
+   if (verbose)
+     {
+ #define _(a,b,c) vlib_cli_output (vm, "%-25s " b, a ":", c);
+-      _("Version", "%s", "v" VPP_BUILD_VER);
++      _("Version", "v21.01 (%s)", VPP_BUILD_VER);
+       _("Compiled by", "%s", VPP_BUILD_USER);
+       _("Compile host", "%s", VPP_BUILD_HOST);
+       _("Compile date", "%s", VPP_BUILD_DATE);

--- a/meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
+++ b/meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
@@ -1,6 +1,17 @@
-diff -ruN a/vpp/app/version.c b/vpp/app/version.c
---- a/vpp/app/version.c	2022-11-11 12:17:52.665882031 +0530
-+++ b/vpp/app/version.c	2022-11-12 18:52:32.972360041 +0530
+From 06f1e141bf7ed802d04ba9df90642bb0733319ec Mon Sep 17 00:00:00 2001
+From: Lahari-Kamasetty <k.lahari@capgemini.com>
+Date: Tue, 15 Nov 2022 12:33:11 +0530
+Subject: [PATCH] VPP displayed version string improvements
+
+Signed-off-by: Lahari-Kamasetty <k.lahari@capgemini.com>
+---
+ src/vpp/app/version.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/vpp/app/version.c b/src/vpp/app/version.c
+index db13c8639..ef048ca0a 100644
+--- a/src/vpp/app/version.c
++++ b/src/vpp/app/version.c
 @@ -16,6 +16,8 @@
  #include <vppinfra/cpu.h>
  #include <vpp/app/version.h>
@@ -15,17 +26,19 @@ diff -ruN a/vpp/app/version.c b/vpp/app/version.c
  /** The image version string */
  char *vpe_version_string =
 -  "vpp v" VPP_BUILD_VER
-+  "vpp v" VPP_DISPLAY_VER " ("VPP_BUILD_VER")"
++  "vpp v" VPP_DISPLAY_VER " (v"VPP_BUILD_VER")"
    " built by " VPP_BUILD_USER " on " VPP_BUILD_HOST " at " VPP_BUILD_DATE;
  
  /** The name of the compiler */
-@@ -73,8 +75,8 @@
- 
+@@ -74,7 +76,7 @@ show_vpe_version_command_fn (vlib_main_t * vm,
    if (verbose)
      {
-+      vlib_cli_output (vm, "%-25s %s (%s)\n", "Version:", "v"VPP_DISPLAY_VER, VPP_BUILD_VER);
  #define _(a,b,c) vlib_cli_output (vm, "%-25s " b, a ":", c);
 -      _("Version", "%s", "v" VPP_BUILD_VER);
++      _("Version", "%s", "v" VPP_DISPLAY_VER " (v"VPP_BUILD_VER")");
        _("Compiled by", "%s", VPP_BUILD_USER);
        _("Compile host", "%s", VPP_BUILD_HOST);
        _("Compile date", "%s", VPP_BUILD_DATE);
+-- 
+2.25.1
+

--- a/meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
+++ b/meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
@@ -1,21 +1,31 @@
 diff -ruN a/vpp/app/version.c b/vpp/app/version.c
 --- a/vpp/app/version.c	2022-11-11 12:17:52.665882031 +0530
-+++ b/vpp/app/version.c	2022-11-11 12:29:15.631962472 +0530
-@@ -29,7 +29,7 @@
++++ b/vpp/app/version.c	2022-11-12 18:52:32.972360041 +0530
+@@ -16,6 +16,8 @@
+ #include <vppinfra/cpu.h>
+ #include <vpp/app/version.h>
+ 
++#define VPP_DISPLAY_VER "21.01"
++
+ /** \file
+     Display image version information
+ */
+@@ -29,7 +31,7 @@
  
  /** The image version string */
  char *vpe_version_string =
 -  "vpp v" VPP_BUILD_VER
-+  "vpp v21.01 " "("VPP_BUILD_VER")"
++  "vpp v" VPP_DISPLAY_VER " ("VPP_BUILD_VER")"
    " built by " VPP_BUILD_USER " on " VPP_BUILD_HOST " at " VPP_BUILD_DATE;
  
  /** The name of the compiler */
-@@ -74,7 +74,7 @@
+@@ -73,8 +75,8 @@
+ 
    if (verbose)
      {
++      vlib_cli_output (vm, "%-25s %s (%s)\n", "Version:", "v"VPP_DISPLAY_VER, VPP_BUILD_VER);
  #define _(a,b,c) vlib_cli_output (vm, "%-25s " b, a ":", c);
 -      _("Version", "%s", "v" VPP_BUILD_VER);
-+      _("Version", "v21.01 (%s)", VPP_BUILD_VER);
        _("Compiled by", "%s", VPP_BUILD_USER);
        _("Compile host", "%s", VPP_BUILD_HOST);
        _("Compile date", "%s", VPP_BUILD_DATE);

--- a/meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb
+++ b/meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb
@@ -54,6 +54,7 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/vpp;proto
            file://0045-policer-classify-unrecognized-packets-as-default-TC3.patch \
            file://0046-fix-vpp-for-2R3C-policers.patch \
            file://0047-properly-respond-to-solicited-forus-ICMPv6-NS-messag.patch \
+	   file://0048-vpp-version-format-change.patch \
            "
 
 # TGHQoS and TG features that rely on hqos implementation


### PR DESCRIPTION
Signed-off-by: Lahari-Kamasetty <k.lahari@capgemini.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [ ] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [ ] If this is a non-trivial change, I have already opened an accompanying Issue.
- [ ] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description
"VPP dispalyed version string improvements"

Introduced new patch - meta-qoriq/recipes-extended/vpp/files/0048-vpp-version-format-change.patch
Modified VPP recipe - meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb

## Test Plan

Verified on PUMA , PFA output file

![vpp-version-format-change](https://user-images.githubusercontent.com/113501666/201337112-41c6e177-2023-4bab-814f-ba01cd91cdd3.png)



