### PR TITLE
fix(vpp-chaperone): delete-old-QoS-policers-if-policer-config-is-removed-from-node-configuration

### DIFF
--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
@@ -768,11 +768,11 @@ void VppConfigManager::doNat64Config (VppClient &vppClient)
 
 void VppConfigManager::doCpeConfig (VppClient &vppClient)
 {
-	VppClient::PolicerConfig policerConfig;
-	VppClient::PolicerConfig oldPolicerConfig;
-	u32 policerIndex;
-	bool ifaceStopped = false;
-	std::vector<u32> tableIds;
+  VppClient::PolicerConfig policerConfig;
+  VppClient::PolicerConfig oldPolicerConfig;
+  u32 policerIndex;
+  bool ifaceStopped = false;
+  std::vector<u32> tableIds;
 
   if (cpeConfig_.empty ())
     {
@@ -798,51 +798,56 @@ void VppConfigManager::doCpeConfig (VppClient &vppClient)
               doCpePolicerConfig (vppClient, kv.first.asString (),
                                   kv.second["policers"]);
             }
-					else
-						{
-							vppClient.getClassifierTableIds (tableIds);
-							VppClient::ClassifierTableConfig tableConfig;
-							for (const u32 &tableId : tableIds)
-								{
-									if (!ifaceStopped)
-										{
-											VLOG (1) << "Stopping interface " << kv.first.asString ()
-															 << " before deleting policers";
-											ifaceStopped = true;
-											vppClient.setInterfaceFlags (kv.first.asString (), false);
-										}
-									tableConfig.tableIndex = tableId;
-									tableConfig.isAdd = 0;  // Delete Table
-									vppClient.addDelClassifierTable (tableConfig);
-								}
-							for (u8 tc = 0; tc <= kMaxTrafficClass; tc++)
-								{
-									std::string interface = kv.first.asString ();
-									std::string policerName = interface + "_" + std::to_string (tc);
-									memcpy (policerConfig.name, policerName.c_str (),
-													sizeof (policerConfig.name));
-									if (vppClient.getPolicer (policerConfig.name, oldPolicerConfig))
-										{
-											if (!ifaceStopped)
-												{
-													VLOG (1) << "Stopping interface " << kv.first.asString ()
-																	 << " before deleting old policers";
-													ifaceStopped = true;
-													vppClient.setInterfaceFlags (kv.first.asString (), false);
-												}
-											policerConfig.isAdd = 0;
-											vppClient.addDelPolicer (policerConfig, policerIndex);
-										}
-									policerConfig.isAdd = 0; // Delete policer
-									vppClient.addDelPolicer (policerConfig, policerIndex);
-								}
-							if (ifaceStopped)
-								{
-									VLOG (1) << "Restarting interface " << kv.first.asString ();
-									vppClient.setInterfaceFlags (kv.first.asString (), true /* up */);
-								}
-							return;
-						}
+          else
+            {
+              vppClient.getClassifierTableIds (tableIds);
+              VppClient::ClassifierTableConfig tableConfig;
+              for (const u32 &tableId : tableIds)
+                {
+                  if (!ifaceStopped)
+                   {
+                     VLOG (1) << "Stopping interface " << kv.first.asString ()
+                              << " before deleting policers";
+                     ifaceStopped = true;
+                     vppClient.setInterfaceFlags (kv.first.asString (), false);
+                   }
+                  tableConfig.tableIndex = tableId;
+                  tableConfig.isAdd = 0;  // Delete Table
+                  vppClient.addDelClassifierTable (tableConfig);
+                }
+              for (u8 tc = 0; tc <= kMaxTrafficClass; tc++)
+                {
+                  std::string interface = kv.first.asString ();
+                  std::string policerName = interface + "_" +
+                                            std::to_string (tc);
+                  memcpy (policerConfig.name, policerName.c_str (),
+                          sizeof (policerConfig.name));
+                  if (vppClient.getPolicer (policerConfig.name,
+                                            oldPolicerConfig))
+                    {
+                      if (!ifaceStopped)
+                        {
+                          VLOG (1) << "Stopping interface "
+                                   << kv.first.asString ()
+                                   << " before deleting old policers";
+                          ifaceStopped = true;
+                          vppClient.setInterfaceFlags (kv.first.asString (),
+                                                       false);
+                        }
+                      policerConfig.isAdd = 0;
+                      vppClient.addDelPolicer (policerConfig, policerIndex);
+                    }
+                  policerConfig.isAdd = 0; // Delete policer
+                  vppClient.addDelPolicer (policerConfig, policerIndex);
+                }
+              if (ifaceStopped)
+                {
+                  VLOG (1) << "Restarting interface " << kv.first.asString ();
+                  vppClient.setInterfaceFlags (kv.first.asString (), 
+                                               true /* up */);
+                }
+              return;
+             }
           if (kv.second.count ("dhcpRelay"))
             {
               LOG (INFO) << "Configuring DHCPv6 on'" << kv.first << "'.";

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
@@ -767,7 +767,7 @@ void VppConfigManager::doNat64Config (VppClient &vppClient)
 }
 
 void VppConfigManager::deleteExistingPolicers (VppClient &vppClient,
-                                              const std::string &cpe_interface)
+                                              const std::string &cpeInterface)
 {
   VppClient::PolicerConfig policerConfig;
   VppClient::PolicerConfig oldPolicerConfig;
@@ -781,10 +781,10 @@ void VppConfigManager::deleteExistingPolicers (VppClient &vppClient,
     {
       if (!ifaceStopped)
         {
-          VLOG (1) << "Stopping interface " << cpe_interface 
+          VLOG (1) << "Stopping interface " << cpeInterface
                    << " before deleting policers";
           ifaceStopped = true;
-          vppClient.setInterfaceFlags (cpe_interface, false);
+          vppClient.setInterfaceFlags (cpeInterface, false);
         }
        tableConfig.tableIndex = tableId;
        tableConfig.isAdd = 0;  // Delete Table
@@ -792,17 +792,17 @@ void VppConfigManager::deleteExistingPolicers (VppClient &vppClient,
     }
   for (u8 tc = 0; tc <= kMaxTrafficClass; tc++)
     {
-      std::string policerName = cpe_interface + "_" + std::to_string (tc);
+      std::string policerName = cpeInterface + "_" + std::to_string (tc);
       memcpy (policerConfig.name, policerName.c_str (),
               sizeof (policerConfig.name));
       if (vppClient.getPolicer (policerConfig.name, oldPolicerConfig))
         {
           if (!ifaceStopped)
             {
-              VLOG (1) << "Stopping interface " << cpe_interface
+              VLOG (1) << "Stopping interface " << cpeInterface
                        << " before deleting old policers";
               ifaceStopped = true;
-              vppClient.setInterfaceFlags (cpe_interface, false);
+              vppClient.setInterfaceFlags (cpeInterface, false);
             }
           policerConfig.isAdd = 0;
           vppClient.addDelPolicer (policerConfig, policerIndex);
@@ -813,8 +813,8 @@ void VppConfigManager::deleteExistingPolicers (VppClient &vppClient,
 
   if (ifaceStopped)
     {
-      VLOG (1) << "Restarting interface " << cpe_interface;
-      vppClient.setInterfaceFlags (cpe_interface, true /* up */);
+      VLOG (1) << "Restarting interface " << cpeInterface;
+      vppClient.setInterfaceFlags (cpeInterface, true /* up */);
      }
   return;
 }

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
@@ -768,6 +768,12 @@ void VppConfigManager::doNat64Config (VppClient &vppClient)
 
 void VppConfigManager::doCpeConfig (VppClient &vppClient)
 {
+	VppClient::PolicerConfig policerConfig;
+	VppClient::PolicerConfig oldPolicerConfig;
+	u32 policerIndex;
+	bool ifaceStopped = false;
+	std::vector<u32> tableIds;
+
   if (cpeConfig_.empty ())
     {
       // Use deprecated CPE config if cpeConfig is empty.
@@ -792,6 +798,51 @@ void VppConfigManager::doCpeConfig (VppClient &vppClient)
               doCpePolicerConfig (vppClient, kv.first.asString (),
                                   kv.second["policers"]);
             }
+					else
+						{
+							vppClient.getClassifierTableIds (tableIds);
+							VppClient::ClassifierTableConfig tableConfig;
+							for (const u32 &tableId : tableIds)
+								{
+									if (!ifaceStopped)
+										{
+											VLOG (1) << "Stopping interface " << kv.first.asString ()
+															 << " before deleting policers";
+											ifaceStopped = true;
+											vppClient.setInterfaceFlags (kv.first.asString (), false);
+										}
+									tableConfig.tableIndex = tableId;
+									tableConfig.isAdd = 0;  // Delete Table
+									vppClient.addDelClassifierTable (tableConfig);
+								}
+							for (u8 tc = 0; tc <= kMaxTrafficClass; tc++)
+								{
+									std::string interface = kv.first.asString ();
+									std::string policerName = interface + "_" + std::to_string (tc);
+									memcpy (policerConfig.name, policerName.c_str (),
+													sizeof (policerConfig.name));
+									if (vppClient.getPolicer (policerConfig.name, oldPolicerConfig))
+										{
+											if (!ifaceStopped)
+												{
+													VLOG (1) << "Stopping interface " << kv.first.asString ()
+																	 << " before deleting old policers";
+													ifaceStopped = true;
+													vppClient.setInterfaceFlags (kv.first.asString (), false);
+												}
+											policerConfig.isAdd = 0;
+											vppClient.addDelPolicer (policerConfig, policerIndex);
+										}
+									policerConfig.isAdd = 0; // Delete policer
+									vppClient.addDelPolicer (policerConfig, policerIndex);
+								}
+							if (ifaceStopped)
+								{
+									VLOG (1) << "Restarting interface " << kv.first.asString ();
+									vppClient.setInterfaceFlags (kv.first.asString (), true /* up */);
+								}
+							return;
+						}
           if (kv.second.count ("dhcpRelay"))
             {
               LOG (INFO) << "Configuring DHCPv6 on'" << kv.first << "'.";

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
@@ -1669,12 +1669,10 @@ void VppConfigManager::doCpePolicerConfig (VppClient &vppClient,
     }
   else
     {
-      LOG (ERROR) << "Interface does not have classifier table";
+      LOG (INFO) << "Interface does not have classifier table";
     }
-
   if (isAdd)
     {
-
       // Create table
       tableConfig.isAdd = 1; // Add
       // Skip 14 bytes for Ethernet header, 4 bits for IPv6 version header;
@@ -1760,11 +1758,6 @@ void VppConfigManager::doCpePolicerConfig (VppClient &vppClient,
           VLOG (1) << "Remove old policer " << policerConfig.name;
           policerConfig.isAdd = 0; // Delete
           vppClient.addDelPolicer (policerConfig, policerIndex);
-
-          if (!isAdd)
-            {
-              continue;
-            }
         }
       if (isAdd)
         {

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
@@ -795,7 +795,8 @@ void VppConfigManager::doCpeConfig (VppClient &vppClient)
           else
             {
               LOG (INFO) << "Deleting policers for CPE interface " << kv.first;
-              doCpePolicerConfig (vppClient, kv.first.asString (), 0, false);
+              doCpePolicerConfig (vppClient, kv.first.asString (),
+                                  nullptr, false);
             }
           if (kv.second.count ("dhcpRelay"))
             {
@@ -1669,7 +1670,7 @@ void VppConfigManager::doCpePolicerConfig (VppClient &vppClient,
     }
   else
     {
-      LOG (INFO) << "Interface does not have classifier table";
+      VLOG (1) << "Interface does not have classifier table";
     }
   if (isAdd)
     {

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
@@ -44,11 +44,7 @@ private:
 
   // Add and delete CPE Policers.
   void doCpePolicerConfig (VppClient &vppClient, const std::string &interface,
-                           const folly::dynamic &policers);
-
-  // Delete Existing CPE Policers.
-  void deleteExistingPolicers (VppClient &vppClient,
-                               const std::string &cpeInterface);
+                           const folly::dynamic &policers, bool policerPresent);
 
   // Derive CPE IP prefix based on node prefix.
   std::string deriveCpeIpPrefix (VppClient &vppClient,

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
@@ -46,9 +46,9 @@ private:
   void doCpePolicerConfig (VppClient &vppClient, const std::string &interface,
                            const folly::dynamic &policers);
 
-  // Delete Existing CPE Poliers.
+  // Delete Existing CPE Policers.
   void deleteExistingPolicers (VppClient &vppClient,
-                               const std::string &cpe_interface);
+                               const std::string &cpeInterface);
 
   // Derive CPE IP prefix based on node prefix.
   std::string deriveCpeIpPrefix (VppClient &vppClient,

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
@@ -46,6 +46,10 @@ private:
   void doCpePolicerConfig (VppClient &vppClient, const std::string &interface,
                            const folly::dynamic &policers);
 
+  // Delete Existing CPE Poliers.
+  void deleteExistingPolicers (VppClient &vppClient,
+                               const std::string &cpe_interface);
+
   // Derive CPE IP prefix based on node prefix.
   std::string deriveCpeIpPrefix (VppClient &vppClient,
                                  const std::string &interface);

--- a/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
+++ b/src/vpp_plugins/vpp-chaperone/VppConfigManager.h
@@ -44,7 +44,7 @@ private:
 
   // Add and delete CPE Policers.
   void doCpePolicerConfig (VppClient &vppClient, const std::string &interface,
-                           const folly::dynamic &policers, bool policerPresent);
+                           const folly::dynamic &policers, bool isAdd);
 
   // Derive CPE IP prefix based on node prefix.
   std::string deriveCpeIpPrefix (VppClient &vppClient,


### PR DESCRIPTION
fix(vpp-chaperone): delete-old-QoS-policers-if-policer-config-is-removed-from-node-configuration
Signed-off-by: Lahari-Kamasetty <k.lahari@capgemini.com>

<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [ ] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [ ] If this is a non-trivial change, I have already opened an accompanying Issue.
- [ ] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

Delete old QoS policers if policer config is removed from node configuration

Modified the files : 
src/vpp_plugins/vpp-chaperone/VppConfigManager.cpp
src/vpp_plugins/vpp-chaperone/VppConfigManager.h

## Test Plan

Verified on PUMA, PFA output file

[vppctl-show-policer-output.txt](https://github.com/terragraph/meta-terragraph/files/10175364/vppctl-show-policer-output.txt)

