### PR TITLE
fix: update nxp sources from codeaurora to github

### DIFF
--- a/meta-qoriq/recipes-bsp/atf/atf_19.09.bb
+++ b/meta-qoriq/recipes-bsp/atf/atf_19.09.bb
@@ -11,7 +11,7 @@ do_compile[depends] += "rcw:do_deploy u-boot:do_deploy"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/atf;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/atf.git;protocol=https;nobranch=1 \
            file://0001-Makefile-add-CC-gcc.patch \
            file://0001-Adaptations-for-Puma.patch \
            "

--- a/meta-qoriq/recipes-bsp/ppa/ppa_git.bb
+++ b/meta-qoriq/recipes-bsp/ppa/ppa_git.bb
@@ -6,8 +6,8 @@ DEPENDS += "u-boot-mkimage-native dtc-native"
 
 inherit deploy
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/ppa-generic;nobranch=1;protocol=http \
-    file://0001-fix-path-error.patch \
+SRC_URI = "git://github.com/nxp-qoriq/ppa-generic.git;protocol=https;nobranch=1 \
+           file://0001-fix-path-error.patch \
 "
 SRCREV = "90e13c9e148972f75f5f2e7f7a904dabf1586049"
 

--- a/meta-qoriq/recipes-bsp/rcw/rcw_git.bb
+++ b/meta-qoriq/recipes-bsp/rcw/rcw_git.bb
@@ -7,7 +7,7 @@ DEPENDS += "tcl-native"
 
 inherit deploy siteinfo
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/rcw;nobranch=1;protocol=https"
+SRC_URI = "git://github.com/nxp-qoriq/rcw.git;nobranch=1;protocol=https"
 SRCREV = "f1377876cc06a87ec8afa8a3412ca7c8455861f2"
 
 S = "${WORKDIR}/git"

--- a/meta-qoriq/recipes-bsp/u-boot/u-boot-qoriq-common_2018.09.inc
+++ b/meta-qoriq/recipes-bsp/u-boot/u-boot-qoriq-common_2018.09.inc
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = " \
     file://Licenses/lgpl-2.1.txt;md5=4fbd65380cdd255951079008b364516c \
 "
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/u-boot;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/u-boot.git;protocol=https;nobranch=1"
 SRCREV= "80b2d2bc4cab0a8363c9b7eba8064b1795f12670"
 
 S = "${WORKDIR}/git"

--- a/meta-qoriq/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
+++ b/meta-qoriq/recipes-dpaa2/gpp-aioptool/gpp-aioptool_git.bb
@@ -6,7 +6,7 @@ SECTION = "dpaa2"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=386a6287daa6504b7e7e5014ddfb3987"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/gpp-aioptool;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/gpp-aioptool.git;protocol=https;nobranch=1 \
 "
 SRCREV = "5160558bb6830c233d69b1e84d56c8bebac427c6"
 

--- a/meta-qoriq/recipes-dpaa2/mc-utils/mc-utils.bb
+++ b/meta-qoriq/recipes-dpaa2/mc-utils/mc-utils.bb
@@ -6,7 +6,7 @@ DEPENDS = "dtc-native"
 
 inherit deploy
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/mc-utils.git"
+SRC_URI = "git://github.com/nxp-qoriq/mc-utils.git;protocol=https"
 SRCREV = "8b3fe8cadba4a091c5ed49c25f2c33111c368426"
 
 S = "${WORKDIR}/git"
@@ -60,4 +60,3 @@ FILES_${PN}-image += "/boot"
 
 COMPATIBLE_MACHINE = "(ls2080ardb|ls2088a|ls1088a)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-

--- a/meta-qoriq/recipes-dpaa2/restool/restool_git.bb
+++ b/meta-qoriq/recipes-dpaa2/restool/restool_git.bb
@@ -4,9 +4,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=ec8d84e9cd4de287e290275d09db27f0"
 
 RDEPENDS_${PN} += "bash"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/restool.git;nobranch=1 \
-    file://0001-restool-fix-build-error-with-gcc7.patch \
-    file://0002-Use-environment-variable-to-disable-bus-rescans.patch \
+SRC_URI = "git://github.com/nxp-qoriq/restool.git;protocol=https;nobranch=1 \
+           file://0001-restool-fix-build-error-with-gcc7.patch \
+           file://0002-Use-environment-variable-to-disable-bus-rescans.patch \
 "
 # quilts .pc makes vendor makefile unhappy
 PATCHTOOL = "git"

--- a/meta-qoriq/recipes-extended/dpdk/dpdk-extras_git.bb
+++ b/meta-qoriq/recipes-extended/dpdk/dpdk-extras_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=4ac6ab4e4bcf4c79cb9257f3c61934f6"
 
 RDEPENDS_${PN} = "bash"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/dpdk-extras.git;nobranch=1"
+SRC_URI = "git://github.com/nxp-qoriq/dpdk-extras.git;protocol=https;nobranch=1"
 SRCREV = "d17f3e065474a41e314ff73b9035e5b3dc021a28"
 
 S = "${WORKDIR}/git"

--- a/meta-qoriq/recipes-extended/dpdk/dpdk_21.08-lsdk.bb
+++ b/meta-qoriq/recipes-extended/dpdk/dpdk_21.08-lsdk.bb
@@ -11,7 +11,7 @@ DEPENDS_class-target += "virtual/kernel openssl"
 
 inherit meson module-base kernel-module-split
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/dpdk;protocol=https;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/dpdk.git;protocol=https;nobranch=1 \
            file://0001-meson-build-fixes.patch \
            file://0002-fix-vfio.patch \
            file://0003-Fix-interrupt-type-selection-for-MSI.patch \

--- a/meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb
+++ b/meta-qoriq/recipes-extended/vpp/vpp_21.08-lsdk.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${S}/../LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 DEPENDS = "openssl python3-ply-native"
 DEPENDS_append_class-target = " virtual/kernel dpdk util-linux numactl kernel-module-direct-vpp"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/vpp;protocol=https;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/vpp.git;protocol=https;nobranch=1 \
            file://0001-optionally-include-wil6210-pmd-in-dpdk.patch \
            file://0002-cmake-find-dpdk-better.patch \
            file://0003-dpdk-teach-plugin-about-wigig-interfaces.patch \
@@ -54,7 +54,7 @@ SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/vpp;proto
            file://0045-policer-classify-unrecognized-packets-as-default-TC3.patch \
            file://0046-fix-vpp-for-2R3C-policers.patch \
            file://0047-properly-respond-to-solicited-forus-ICMPv6-NS-messag.patch \
-	   file://0048-vpp-version-format-change.patch \
+           file://0048-vpp-version-format-change.patch \
            "
 
 # TGHQoS and TG features that rely on hqos implementation

--- a/meta-qoriq/recipes-kernel/linux/linux-qoriq_4.14.inc
+++ b/meta-qoriq/recipes-kernel/linux/linux-qoriq_4.14.inc
@@ -6,7 +6,7 @@ SECTION = "kernel"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
-SRC_URI = "git://source.codeaurora.org/external/qoriq/qoriq-components/linux;nobranch=1 \
+SRC_URI = "git://github.com/nxp-qoriq/linux.git;protocol=https;nobranch=1 \
            file://linux_qoriq_4_14_fixes.patch \
 "
 SRCREV = "328b263103fbd83f7c7a5d42acef266375a2f717"
@@ -36,7 +36,7 @@ do_merge_delta_config[dirs] = "${B}"
 do_merge_delta_config() {
     # create config with make config
     oe_runmake  -C ${S} O=${B} ${KERNEL_DEFCONFIG}
-    
+
     # check if bigendian is enabled
     if [ "${SITEINFO_ENDIANNESS}" = "be" ]; then
         echo "CONFIG_CPU_BIG_ENDIAN=y" >> .config


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

<!--
Describe your changes, or link to another Issue or Pull Request.
-->
NXP has moved all sources from CodeAurora onto GitHub. Update bitbake recipes accordingly.

## Test Plan

<!--
Describe how you have tested your changes.
Please include relevant environment details, logs, screenshots, etc.
Do not provide customer information that could be considered personally identifiable information (PII).
-->
```
$ source tg-init-build-env meta-qca build-qca
$ bitbake -c do_fetch atf ppa rcw gpp-aioptool mc-utils restool dpdk dpdk-extras u-boot-qoriq linux-terragraph vpp
```
