### PR TITLE
fix(ci): pin 'black' version in .ptrconfig

### DIFF
--- a/.ptrconfig
+++ b/.ptrconfig
@@ -3,7 +3,7 @@ exclude_patterns =
   build*
   yocto
 venv_pkgs =
-  black
+  black==22.12.0
   coverage
   flake8
   git+https://github.com/cooperlees/aioexabgp


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request!
Please carefully follow the instructions below.
-->

## Prerequisites

- [x] I have read the [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] If this is a non-trivial change, I have already opened an accompanying Issue.
- [x] If applicable, I have included documentation updates alongside my code changes.

<!--
Please remember to sign the CLA, although you can also sign it after submitting this Pull Request.
The CLA is required for us to merge your Pull Request.
-->

## Description

<!--
Describe your changes, or link to another Issue or Pull Request.
-->
Fix Python CI workflow by pinning "black" formatter version to 22.12.0 since the rules keep changing.

## Test Plan

<!--
Describe how you have tested your changes.
Please include relevant environment details, logs, screenshots, etc.
Do not provide customer information that could be considered personally identifiable information (PII).
-->
Workflow passes
